### PR TITLE
Support Android flavors and buildTypes out of the box and add include Configuration extension point to Generator.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
-language: groovy
+language: android
 
-groovy:
-  - 2.3.6
-  - 2.3.9
-
-jdk:
-  - oraclejdk8
+jdk: oraclejdk8
 
 before_install:
   - pip install --user codecov
-
-install: true
+  # Download SDK
+  - yes | sdkmanager "tools" &>/dev/null
+  - yes | sdkmanager "platform-tools" &>/dev/null
+  - yes | sdkmanager "build-tools;27.0.3" &>/dev/null
+  - yes | sdkmanager "platforms;android-27" &>/dev/null
+  # Update remaining dependencies and accept licenses
+  - yes | sdkmanager --update &>/dev/null
+  - yes | sdkmanager --licenses &>/dev/null
 
 script: ./gradlew clean build
 
@@ -32,7 +33,11 @@ notifications:
 
 sudo: false
 
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
 cache:
   directories:
-    - $HOME/.gradle
-    - $HOME/.m2
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+    - $HOME/.android/build-cache

--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,16 @@ pluginBundle {
   }
 }
 
+tasks.withType(Test) {
+  testLogging {
+    events "failed"
+    exceptionFormat "full"
+    showExceptions true
+    showStackTraces true
+    showCauses true
+  }
+}
+
 task wrapper(type: Wrapper) {
   gradleVersion = '4.6'
   distributionType = Wrapper.DistributionType.ALL

--- a/build.gradle
+++ b/build.gradle
@@ -93,16 +93,6 @@ pluginBundle {
   }
 }
 
-tasks.withType(Test) {
-  testLogging {
-    events "failed"
-    exceptionFormat "full"
-    showExceptions true
-    showStackTraces true
-    showCauses true
-  }
-}
-
 task wrapper(type: Wrapper) {
   gradleVersion = '4.6'
   distributionType = Wrapper.DistributionType.ALL

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ dependencies {
 
   testImplementation 'junit:junit:4.12'
   testImplementation 'org.assertj:assertj-core:3.9.1'
+  testImplementation 'com.android.tools.build:gradle:3.0.1'
   testImplementation "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion"
 }
 

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorExtension.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorExtension.kt
@@ -3,6 +3,7 @@ package com.vanniktech.dependency.graph.generator
 import com.vanniktech.dependency.graph.generator.DependencyGraphGeneratorExtension.Generator.Companion.ALL
 import com.vanniktech.dependency.graph.generator.dot.GraphFormattingOptions
 import com.vanniktech.dependency.graph.generator.dot.Header
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedDependency
 
 /**
@@ -33,7 +34,13 @@ open class DependencyGraphGeneratorExtension {
     /** The formatting options for the root - the project this generator is applied too. */
     val rootFormattingOptions: GraphFormattingOptions = GraphFormattingOptions(),
     /** Optional header that can be displayed wrapped around the graph. */
-    val header: Header? = null
+    val header: Header? = null,
+    /** Return true when you want to include this configuration, false otherwise. */
+    val includeConfiguration: (Configuration) -> Boolean = {
+      // By default we'll include everything that's on the compileClassPath except test, UnitTest and AndroidTest configurations.
+      val raw = it.name.replace("compileClasspath", "", ignoreCase = true)
+      it.name.contains("compileClassPath", ignoreCase = true) && listOf("test", "AndroidTest", "UnitTest").none { raw.contains(it) }
+    }
   ) {
     /** Gradle task name that is associated with this generator. */
     val gradleTaskName = "generateDependencyGraph${name.capitalize()}"

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DotGenerator.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DotGenerator.kt
@@ -43,12 +43,7 @@ internal class DotGenerator(
         .flatMap { project ->
           project.configurations
               .filter { it.isCanBeResolved }
-              .filter {
-                // TODO this is not optimal but will do for now.
-                val isCompileClassPath = it.name == "compileClasspath"
-                val isAndroidProjectClassPath = it.name == "debugCompileClasspath" || it.name == "releaseCompileClasspath"
-                isCompileClassPath || isAndroidProjectClassPath
-              }
+              .filter { generator.includeConfiguration.invoke(it) }
               .flatMap { it.resolvedConfiguration.firstLevelModuleDependencies }
               .map { project to it }
         }


### PR DESCRIPTION
Fixes #7

Now everything will be included by default and if wanted one can provide a custom Generator to filter for instance for only one flavor.