### PR TITLE
Adding Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ apply plugin: "com.vanniktech.dependency.graph.generator"
 
 Note that this plugin can be applied at the root of the project or at a specific project. Both cases will just work.
 
-This plugin is using the `dot` command line tool for generating the graphs hence you need to install it. Mac users can use `brew install graphviz`. Ubuntu users can `sudo apt-get install graphviz`.
+This plugin is using the `dot` command line tool for generating the graphs hence you need to install it.
+  - Mac (with [Homebrew](https://brew.sh/) installed): `brew install graphviz`
+  - Windows (with [Chocolatey](https://chocolatey.org/) installed): `choco install graphviz`
+  - Ubuntu: `sudo apt-get install graphviz`
 
 Information: [This plugin is also available on Gradle plugins](https://plugins.gradle.org/plugin/com.vanniktech.dependency.graph.generator)
 

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -29,6 +29,7 @@ open class DependencyGraphGeneratorTask : DefaultTask() {
       val message = when {
         Os.isFamily(Os.FAMILY_MAC) -> "Please install via: brew install graphviz"
         Os.isFamily(Os.FAMILY_UNIX) -> "Please install via: sudo apt-get install graphviz"
+        Os.isFamily(Os.FAMILY_WINDOWS) -> "Please install via: choco install graphviz"
         else -> "Please find a way to install it."
       }
 

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -33,9 +33,9 @@ open class DependencyGraphGeneratorTask : DefaultTask() {
 
     if (result.exitValue != 0) {
       val message = when {
+        Os.isFamily(Os.FAMILY_WINDOWS) -> "Please install via: choco install graphviz"
         Os.isFamily(Os.FAMILY_MAC) -> "Please install via: brew install graphviz"
         Os.isFamily(Os.FAMILY_UNIX) -> "Please install via: sudo apt-get install graphviz"
-        Os.isFamily(Os.FAMILY_WINDOWS) -> "Please install via: choco install graphviz"
         else -> "Please find a way to install it."
       }
 

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -20,8 +20,7 @@ open class DependencyGraphGeneratorTask : DefaultTask() {
   @TaskAction fun run() {
     val result = project.exec {
       it.standardOutput = NullOutputStream // Don't print the output.
-      it.executable = "command"
-      it.args("-v", "dot")
+      it.commandLine("dot", "-v")
       it.isIgnoreExitValue = true
     }
 

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -20,7 +20,12 @@ open class DependencyGraphGeneratorTask : DefaultTask() {
   @TaskAction fun run() {
     val result = project.exec {
       it.standardOutput = NullOutputStream // Don't print the output.
-      it.commandLine("dot", "-v")
+      if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        it.executable = "cmd"
+      } else {
+        it.executable = "command"
+      }
+      it.args("-v", "dot")
       it.isIgnoreExitValue = true
     }
 


### PR DESCRIPTION
Added instructions for installing Graphviz via Windows, and clarifying that the Mac instructions requires Homebrew to be installed