### PR TITLE
Adding minimum Gradle version to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Gradle plugin that lets you visualize your dependencies in a graph.
 
 # Set up
 
-[Gradle 4.0](https://docs.gradle.org/4.0/release-notes.html) or higher is requred.
+[Gradle 4.0](https://docs.gradle.org/4.0/release-notes.html) or higher is required.
 
 ```gradle
 buildscript {

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Gradle plugin that lets you visualize your dependencies in a graph.
 
 # Set up
 
+[Gradle 4.0](https://docs.gradle.org/4.0/release-notes.html) or higher is requred.
+
 ```gradle
 buildscript {
   repositories {


### PR DESCRIPTION
Addresses #20, which is now a "won't fix" because the minimum required version is now documented to be 4.0.