### PR TITLE
mark task inputs as such.

### DIFF
--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorExtension.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorExtension.kt
@@ -12,6 +12,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedDependency
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
 
 /**
  * Extension for dependency graph generation.
@@ -78,6 +79,9 @@ open class DependencyGraphGeneratorExtension(project: Project) {
     val gradleTaskName = "generateDependencyGraph${name.capitalize()}"
     internal val outputFileName = "dependency-graph${name.toHyphenCase().nonEmptyPrepend("-")}"
     internal val outputFileNameDot = "$outputFileName.dot"
+
+    @get:[Optional Input] internal val rawLabel: String?
+      get() = label?.toString()
 
     companion object {
       /** Default behavior which will include everything as is. */

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorExtension.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorExtension.kt
@@ -11,6 +11,7 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.ResolvedDependency
+import org.gradle.api.tasks.Input
 
 /**
  * Extension for dependency graph generation.
@@ -49,29 +50,29 @@ open class DependencyGraphGeneratorExtension(project: Project) {
      * The name of this type of generator that should be in lowerCamelCase.
      * The task name as well as the output files will use this name.
      */
-    var name: String = "",
+    @get:Input var name: String = "",
     /** Return true when you want to include this dependency, false otherwise. */
-    var include: (ResolvedDependency) -> Boolean = { true },
+    @get:Input var include: (ResolvedDependency) -> Boolean = { true },
     /** Return true when you want to include the children of this dependency, false otherwise. */
-    var children: (ResolvedDependency) -> Boolean = { true },
+    @get:Input var children: (ResolvedDependency) -> Boolean = { true },
     /** Allows to change the node for the given dependency. */
-    var dependencyNode: (MutableNode, ResolvedDependency) -> MutableNode = { node, _ -> node },
+    @get:Input var dependencyNode: (MutableNode, ResolvedDependency) -> MutableNode = { node, _ -> node },
     /** Allows to change the node for the given project. */
-    var projectNode: (MutableNode, Project) -> MutableNode = { node, _ -> node },
+    @get:Input var projectNode: (MutableNode, Project) -> MutableNode = { node, _ -> node },
     /** Optional label that can be displayed wrapped around the graph. */
-    var label: Label? = null,
+    var label: Label? = null, //Not serializable making it unusable as an Input
     /** Return true when you want to include this configuration, false otherwise. */
-    var includeConfiguration: (Configuration) -> Boolean = {
+    @get:Input var includeConfiguration: (Configuration) -> Boolean = {
       // By default we'll include everything that's on the compileClassPath except test, UnitTest and AndroidTest configurations.
       val raw = it.name.replace("compileClasspath", "", ignoreCase = true)
       it.name.contains("compileClassPath", ignoreCase = true) && listOf("test", "AndroidTest", "UnitTest").none { raw.contains(it) }
     },
     /** Return true when you want to include this project, false otherwise. */
-    var includeProject: (Project) -> Boolean = { true },
+    @get:Input var includeProject: (Project) -> Boolean = { true },
     /** Return the output formats you'd like to be generated. */
-    var outputFormats: List<Format> = listOf(PNG, SVG),
+    @get:Input var outputFormats: List<Format> = listOf(PNG, SVG),
     /** Allows you to mutate the graph and add things as needed. */
-    var graph: (MutableGraph) -> MutableGraph = { it }
+    @get:Input var graph: (MutableGraph) -> MutableGraph = { it }
   ) {
     /** Gradle task name that is associated with this generator. */
     val gradleTaskName = "generateDependencyGraph${name.capitalize()}"
@@ -93,15 +94,15 @@ open class DependencyGraphGeneratorExtension(project: Project) {
      * The name of this type of generator that should be in lowerCamelCase.
      * The task name as well as the output files will use this name.
      */
-    var name: String = "",
+    @get:Input var name: String = "",
     /** Allows to change the node for the given project. */
-    var projectNode: (MutableNode, Project) -> MutableNode = { node, _ -> node },
+    @get:Input var projectNode: (MutableNode, Project) -> MutableNode = { node, _ -> node },
     /** Return true when you want to include this project, false otherwise. */
-    var includeProject: (Project) -> Boolean = { true },
+    @get:Input var includeProject: (Project) -> Boolean = { true },
     /** Return the output formats you'd like to be generated. */
-    var outputFormats: List<Format> = listOf(PNG, SVG),
+    @get:Input var outputFormats: List<Format> = listOf(PNG, SVG),
     /** Allows you to mutate the graph and add things as needed. */
-    var graph: (MutableGraph) -> MutableGraph = { it }
+    @get:Input var graph: (MutableGraph) -> MutableGraph = { it }
   ) {
     /** Gradle task name that is associated with this generator. */
     val gradleTaskName = "generateProjectDependencyGraph${name.capitalize()}"

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -4,17 +4,26 @@ import com.vanniktech.dependency.graph.generator.DependencyGraphGeneratorExtensi
 import guru.nidi.graphviz.engine.Graphviz
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 @CacheableTask open class DependencyGraphGeneratorTask : DefaultTask() {
-  lateinit var generator: Generator // TODO does this need to be an input? Quick testing shows no.
+  @get:Nested lateinit var generator: Generator
 
   @OutputDirectory lateinit var outputDirectory: File
 
+  val graph by lazy {
+    DependencyGraphGenerator(project, generator).generateGraph()
+  }
+
+  @get:Input val dotFormatGraph by lazy {
+    graph.toString()
+  }
+
   @TaskAction fun run() {
-    val graph = DependencyGraphGenerator(project, generator).generateGraph()
     File(outputDirectory, generator.outputFileNameDot).writeText(graph.toString())
 
     val graphviz = Graphviz.fromGraph(graph)

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
@@ -4,17 +4,26 @@ import com.vanniktech.dependency.graph.generator.DependencyGraphGeneratorExtensi
 import guru.nidi.graphviz.engine.Graphviz
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 @CacheableTask open class ProjectDependencyGraphGeneratorTask : DefaultTask() {
-  lateinit var projectGenerator: ProjectGenerator // TODO does this need to be an input? Quick testing shows no.
+  @get:Nested lateinit var projectGenerator: ProjectGenerator
 
   @OutputDirectory lateinit var outputDirectory: File
 
+  val graph by lazy {
+    ProjectDependencyGraphGenerator(project, projectGenerator).generateGraph()
+  }
+
+  @get:Input val dotFormatGraph by lazy {
+    graph.toString()
+  }
+
   @TaskAction fun run() {
-    val graph = ProjectDependencyGraphGenerator(project, projectGenerator).generateGraph()
     File(outputDirectory, projectGenerator.outputFileNameDot).writeText(graph.toString())
 
     val graphviz = Graphviz.fromGraph(graph)

--- a/src/test/java/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorPluginTest.kt
+++ b/src/test/java/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorPluginTest.kt
@@ -74,15 +74,12 @@ class DependencyGraphGeneratorPluginTest {
         |}
         |""".trimMargin())
 
-    val stdErrorWriter = StringWriter()
-
     fun runBuild(): BuildResult {
       return GradleRunner.create()
         .withPluginClasspath()
         .withGradleVersion(gradleVersion)
         .withProjectDir(testProjectDir.root)
         .withArguments("generateDependencyGraph", "generateProjectDependencyGraph")
-        .forwardStdError(stdErrorWriter)
         .build()
     }
 
@@ -213,14 +210,11 @@ class DependencyGraphGeneratorPluginTest {
 
     val empty = testProjectDir.newFolder("empty").run { parentFile.name + name }
 
-    val stdErrorWriter = StringWriter()
-
     val result = GradleRunner.create()
         .withPluginClasspath()
         .withGradleVersion("5.0")
         .withProjectDir(testProjectDir.root)
         .withArguments("generateDependencyGraph", "generateProjectDependencyGraph")
-        .forwardStdError(stdErrorWriter)
         .build()
 
     result.tasks.filter { it.path.contains("DependencyGraph") }.forEach {

--- a/src/test/java/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorPluginTest.kt
+++ b/src/test/java/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorPluginTest.kt
@@ -4,7 +4,9 @@ import org.assertj.core.api.Java6Assertions.assertThat
 import org.gradle.api.internal.project.DefaultProject
 import org.gradle.api.plugins.JavaLibraryPlugin
 import org.gradle.testfixtures.ProjectBuilder
+import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -54,8 +56,9 @@ class DependencyGraphGeneratorPluginTest {
     integrationTest("5.0")
   }
 
-  private fun integrationTest(gradleVersion: String) {
-    testProjectDir.newFile("build.gradle").writeText("""
+  @Suppress("Detekt.LongMethod") private fun integrationTest(gradleVersion: String) {
+    val buildFile = testProjectDir.newFile("build.gradle")
+    buildFile.writeText("""
         |plugins {
         |  id "java"
         |  id "com.vanniktech.dependency.graph.generator"
@@ -73,16 +76,19 @@ class DependencyGraphGeneratorPluginTest {
 
     val stdErrorWriter = StringWriter()
 
-    GradleRunner.create()
+    fun runBuild(): BuildResult {
+      return GradleRunner.create()
         .withPluginClasspath()
         .withGradleVersion(gradleVersion)
         .withProjectDir(testProjectDir.root)
         .withArguments("generateDependencyGraph", "generateProjectDependencyGraph")
         .forwardStdError(stdErrorWriter)
         .build()
+    }
 
-    // No errors.
-    assertThat(stdErrorWriter).hasToString("")
+    val result = runBuild()
+    assertThat(result.task(":generateDependencyGraph")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.task(":generateProjectDependencyGraph")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
 
     // We don't want to assert the content of the images, just that they exist.
     assertThat(File(testProjectDir.root, "build/reports/dependency-graph/dependency-graph.png")).exists()
@@ -118,6 +124,30 @@ class DependencyGraphGeneratorPluginTest {
         graph ["rank"="same"]
         }
         }""".trimIndent())
+
+    val secondResult = runBuild()
+    assertThat(secondResult.task(":generateDependencyGraph")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    assertThat(secondResult.task(":generateProjectDependencyGraph")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+
+    buildFile.appendText("""
+      |import guru.nidi.graphviz.engine.Format
+      |dependencyGraphGenerator {
+      |  generators {
+      |    configureEach {
+      |      it.outputFormats = [Format.SVG]
+      |    }
+      |  }
+      |  projectGenerators {
+      |    configureEach {
+      |      it.outputFormats = [Format.SVG]
+      |    }
+      |  }
+      |}
+      |""".trimMargin())
+
+    val thirdResult = runBuild()
+    assertThat(thirdResult.task(":generateDependencyGraph")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(thirdResult.task(":generateProjectDependencyGraph")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
   }
 
   @Test @Suppress("Detekt.LongMethod") fun multiProjectIntegrationTest() {
@@ -185,7 +215,7 @@ class DependencyGraphGeneratorPluginTest {
 
     val stdErrorWriter = StringWriter()
 
-    GradleRunner.create()
+    val result = GradleRunner.create()
         .withPluginClasspath()
         .withGradleVersion("5.0")
         .withProjectDir(testProjectDir.root)
@@ -193,8 +223,9 @@ class DependencyGraphGeneratorPluginTest {
         .forwardStdError(stdErrorWriter)
         .build()
 
-    // No errors.
-    assertThat(stdErrorWriter).hasToString("")
+    result.tasks.filter { it.path.contains("DependencyGraph") }.forEach {
+      assertThat(it?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    }
 
     // We don't want to assert the content of the image, just that it exists.
     assertThat(File(testProjectDir.root, "build/reports/dependency-graph/dependency-graph.png")).exists()


### PR DESCRIPTION
was seeing the multi project test fail due to missing PNG outputs, though I don't see how the default `ALL` could be getting initiated with only SVG as the format.

all the graphviz types not being serializable leads to some less than ideal conversion for the input values. 

but this should at least ensure the tasks are marked as dirty when any value that feeds into them changes.

my least favorite element is the `@get:Input val dotFormatGraph` since it ends up running the bulk of the logic to generate it, but was the simplest way to cover all the inputs from the gradle model without completely restructuring the generator logic.

closes #95 