### PR TITLE
Prepare version 0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,14 @@
 # Change Log
 
-Version 0.7.0 *(In development)*
+Version 0.7.0 *(2021-12-18)*
 --------------------------------
+
+- Upgrade Kotlin version [\#141](https://github.com/vanniktech/gradle-dependency-graph-generator-plugin/pull/141) ([carlonzo](https://github.com/carlonzo))
+- Fixing issue #127: README Firebase example for groovy DSL doesn't see… [\#138](https://github.com/vanniktech/gradle-dependency-graph-generator-plugin/pull/138) ([gradlifier](https://github.com/gradlifier))
+- Support generateProjectDependencyGraph in SubProject [\#134](https://github.com/vanniktech/gradle-dependency-graph-generator-plugin/pull/134) ([tedliang](https://github.com/tedliang))
+- Disable publish action in forked repository. [\#133](https://github.com/vanniktech/gradle-dependency-graph-generator-plugin/pull/133) ([vanniktech](https://github.com/vanniktech))
+- Update Gradle Groovy example in README.md [\#128](https://github.com/vanniktech/gradle-dependency-graph-generator-plugin/pull/128) ([fajarnuha](https://github.com/fajarnuha))
+- Delete .travis.yml [\#126](https://github.com/vanniktech/gradle-dependency-graph-generator-plugin/pull/126) ([vanniktech](https://github.com/vanniktech))
 
 Version 0.6.0 *(2021-06-27)*
 ----------------------------

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ buildscript {
     mavenCentral()
   }
   dependencies {
-    classpath "com.vanniktech:gradle-dependency-graph-generator-plugin:0.6.0"
+    classpath "com.vanniktech:gradle-dependency-graph-generator-plugin:0.7.0"
   }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.vanniktech
-VERSION_NAME=0.7.0-SNAPSHOT
+VERSION_NAME=0.7.0
 
 POM_ARTIFACT_ID=gradle-dependency-graph-generator-plugin
 POM_NAME=Gradle Graph Generator Plugin


### PR DESCRIPTION
Hereby the changes to get the version 0.7.0 released as discussed at https://github.com/vanniktech/gradle-dependency-graph-generator-plugin/issues/127#issuecomment-996984259