### PR TITLE
Log output files path: dot, png, svg

### DIFF
--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -25,12 +25,15 @@ import java.io.File
   }
 
   @TaskAction fun run() {
-    File(outputDirectory, generator.outputFileNameDot).writeText(graph.toString())
+    val dot = File(outputDirectory, generator.outputFileNameDot)
+    dot.writeText(graph.toString())
 
     val graphviz = Graphviz.fromGraph(graph)
 
-    generator.outputFormats.forEach {
+    val renders = generator.outputFormats.map {
       graphviz.render(it).toFile(File(outputDirectory, generator.outputFileName))
     }
+
+    listOf(dot).plus(renders).forEach { logger.lifecycle(it.absolutePath) }
   }
 }

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
@@ -25,12 +25,15 @@ import java.io.File
   }
 
   @TaskAction fun run() {
-    File(outputDirectory, projectGenerator.outputFileNameDot).writeText(graph.toString())
+    val dot = File(outputDirectory, projectGenerator.outputFileNameDot)
+    dot.writeText(graph.toString())
 
     val graphviz = Graphviz.fromGraph(graph)
 
-    projectGenerator.outputFormats.forEach {
+    val renders = projectGenerator.outputFormats.map {
       graphviz.render(it).toFile(File(outputDirectory, projectGenerator.outputFileName))
     }
+
+    listOf(dot).plus(renders).forEach { logger.lifecycle(it.absolutePath) }
   }
 }


### PR DESCRIPTION
Fixes #155

Here is what it looks like on Windows:

```
> Task :generateDependencyGraph
C:\...\build\reports\dependency-graph\dependency-graph.dot
C:\...\build\reports\dependency-graph\dependency-graph.png
C:\...\build\reports\dependency-graph\dependency-graph.svg

BUILD SUCCESSFUL in 27s
```

Unfortunately, clickable file uri in IntelliJ's terminal is awful.
On Windows, it works only if the IDE has indexed the file before printing it.
Not sure about the Unix/Macos behavior.