### PR TITLE
Force the dpi value to 100

### DIFF
--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGenerator.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGenerator.kt
@@ -1,6 +1,7 @@
 package com.vanniktech.dependency.graph.generator
 
 import com.vanniktech.dependency.graph.generator.DependencyGraphGeneratorExtension.Generator
+import guru.nidi.graphviz.attribute.GraphAttr
 import guru.nidi.graphviz.attribute.Label
 import guru.nidi.graphviz.attribute.Rank
 import guru.nidi.graphviz.attribute.Rank.RankType
@@ -25,8 +26,7 @@ internal class DependencyGraphGenerator(
   private val nodes = mutableMapOf<String, MutableNode>()
 
   @Suppress("Detekt.SpreadOperator") fun generateGraph(): MutableGraph {
-    val graph = mutGraph("G").setDirected(true)
-
+    val graph = mutGraph("G").setDirected(true).graphAttrs().add(GraphAttr.dpi(100))
     generator.label?.let {
       graph.graphAttrs().add(it)
     }

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGenerator.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGenerator.kt
@@ -2,6 +2,7 @@ package com.vanniktech.dependency.graph.generator
 
 import guru.nidi.graphviz.attribute.Color
 import guru.nidi.graphviz.attribute.Font
+import guru.nidi.graphviz.attribute.GraphAttr
 import guru.nidi.graphviz.attribute.Label
 import guru.nidi.graphviz.attribute.Rank
 import guru.nidi.graphviz.attribute.Rank.RankType
@@ -39,7 +40,7 @@ internal class ProjectDependencyGraphGenerator(
     }
     project.allprojects.filter { it.isDependingOnOtherProject() }.forEach { addProject(it) }
 
-    val graph = mutGraph().setDirected(true)
+    val graph = mutGraph().setDirected(true).graphAttrs().add(GraphAttr.dpi(100))
     graph.graphAttrs().add(Label.of(project.name).locate(Label.Location.TOP), Font.size(DEFAULT_FONT_SIZE))
     graph.nodeAttrs().add(Style.FILLED)
     projects.forEach { addNode(it, dependencies, graph) }

--- a/src/test/java/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorPluginTest.kt
+++ b/src/test/java/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorPluginTest.kt
@@ -110,6 +110,7 @@ class DependencyGraphGeneratorPluginTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "${testProjectDir.root.name}" ["label"="${testProjectDir.root.name}","shape"="rectangle"]
         "orgjetbrainskotlinkotlinstdlib" ["label"="kotlin-stdlib","shape"="rectangle"]
         "orgjetbrainsannotations" ["label"="jetbrains-annotations","shape"="rectangle"]
@@ -143,7 +144,7 @@ class DependencyGraphGeneratorPluginTest {
       """
         digraph {
         edge ["dir"="forward"]
-        graph ["label"="${testProjectDir.root.name}","labelloc"="t","fontsize"="35"]
+        graph ["dpi"="100","label"="${testProjectDir.root.name}","labelloc"="t","fontsize"="35"]
         node ["style"="filled"]
         {
         edge ["dir"="none"]
@@ -284,6 +285,7 @@ class DependencyGraphGeneratorPluginTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "$app" ["label"="app","shape"="rectangle"]
         "$lib1" ["label"="lib1","shape"="rectangle"]
         "$lib" ["label"="lib","shape"="rectangle"]
@@ -318,7 +320,7 @@ class DependencyGraphGeneratorPluginTest {
     fun projectDependencyGraph(label: String) = """
         digraph {
         edge ["dir"="forward"]
-        graph ["label"="$label","labelloc"="t","fontsize"="35"]
+        graph ["dpi"="100","label"="$label","labelloc"="t","fontsize"="35"]
         node ["style"="filled"]
         ":app" ["shape"="rectangle","fillcolor"="#ff8a65"]
         ":lib1" ["fillcolor"="#ff8a65"]

--- a/src/test/java/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTest.kt
+++ b/src/test/java/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTest.kt
@@ -80,6 +80,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "singleempty" ["label"="singleempty","shape"="rectangle"]
         {
         edge ["dir"="none"]
@@ -96,6 +97,7 @@ class DependencyGraphGeneratorTest {
     assertEquals(
       """
         digraph "G" {
+        graph ["dpi"="100"]
         }
       """.trimIndent(),
       DependencyGraphGenerator(singleEmpty, ALL.copy(includeProject = { false })).generateGraph().toString()
@@ -107,6 +109,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "singleempty" ["label"="singleempty","shape"="rectangle"]
         {
         edge ["dir"="none"]
@@ -123,6 +126,7 @@ class DependencyGraphGeneratorTest {
     assertEquals(
       """
         graph "G" {
+        graph ["dpi"="100"]
         "singleempty" ["label"="singleempty","shape"="rectangle"]
         {
         graph ["rank"="same"]
@@ -139,7 +143,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
-        graph ["label"="my custom header","labeljust"="l","labelloc"="t"]
+        graph ["dpi"="100","label"="my custom header","labeljust"="l","labelloc"="t"]
         "singleempty" ["label"="singleempty","shape"="rectangle"]
         {
         edge ["dir"="none"]
@@ -157,6 +161,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "singleempty" ["label"="singleempty","shape"="egg","style"="dotted","color"="#ff0099"]
         {
         edge ["dir"="none"]
@@ -174,6 +179,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "single" ["label"="single","shape"="rectangle"]
         "orgjetbrainskotlinkotlinstdlib" ["label"="kotlin-stdlib","shape"="rectangle"]
         "orgjetbrainsannotations" ["label"="jetbrains-annotations","shape"="rectangle"]
@@ -207,6 +213,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "single" ["label"="single","shape"="rectangle"]
         "orgjetbrainskotlinkotlinstdlib" ["label"="kotlin-stdlib","shape"="rectangle","style"="filled","color"="0.833904937402929 0.4047932090555708 0.5440948801677342"]
         "orgjetbrainsannotations" ["label"="jetbrains-annotations","shape"="rectangle","style"="filled","color"="0.44658757938141413 0.25639393293458856 0.2315484830185478"]
@@ -232,6 +239,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "single" ["label"="single","shape"="rectangle"]
         "orgjetbrainskotlinkotlinstdlib" ["label"="kotlin-stdlib","shape"="rectangle"]
         "ioreactivexrxjava2rxjava" ["label"="rxjava","shape"="rectangle"]
@@ -253,6 +261,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "single" ["label"="single","shape"="rectangle"]
         "orgjetbrainskotlinkotlinstdlib" ["label"="kotlin-stdlib","shape"="rectangle"]
         "orgjetbrainsannotations" ["label"="jetbrains-annotations","shape"="rectangle"]
@@ -276,6 +285,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "singleempty" ["label"="singleempty","shape"="rectangle"]
         "orgapachexmlgraphicsbatikgvt" ["label"="batik-gvt","shape"="rectangle"]
         "orgapachexmlgraphicsbatikbridge" ["label"="batik-bridge","shape"="rectangle"]
@@ -374,6 +384,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "single" ["label"="single","shape"="rectangle"]
         "orgjetbrainskotlinkotlinstdlib" ["label"="kotlin-stdlib","shape"="rectangle"]
         "orgjetbrainsannotations" ["label"="jetbrains-annotations","shape"="rectangle"]
@@ -402,6 +413,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "multimulti1" ["label"="multi1","shape"="rectangle"]
         "orgjetbrainskotlinkotlinstdlib" ["label"="kotlin-stdlib","shape"="rectangle"]
         "orgjetbrainsannotations" ["label"="jetbrains-annotations","shape"="rectangle"]
@@ -437,6 +449,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "android" ["label"="android","shape"="rectangle"]
         "androidarchpersistenceroomruntime" ["label"="persistence-room-runtime","shape"="rectangle"]
         "androidarchpersistenceroomcommon" ["label"="persistence-room-common","shape"="rectangle"]
@@ -483,6 +496,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "android" ["label"="android","shape"="rectangle"]
         "comsquareupsqldelightruntime" ["label"="sqldelight-runtime","shape"="rectangle"]
         "comandroidsupportsupportannotations" ["label"="support-annotations","shape"="rectangle"]
@@ -516,6 +530,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "android" ["label"="android","shape"="rectangle"]
         "ioreactivexrxjava2rxandroid" ["label"="rxandroid","shape"="rectangle"]
         "ioreactivexrxjava2rxjava" ["label"="rxjava","shape"="rectangle"]
@@ -554,6 +569,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "android" ["label"="android","shape"="rectangle"]
         "ioreactivexrxjava2rxjava" ["label"="rxjava","shape"="rectangle"]
         "orgreactivestreamsreactivestreams" ["label"="reactive-streams","shape"="rectangle"]
@@ -592,6 +608,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "android" ["label"="android","shape"="rectangle"]
         "orgjetbrainskotlinkotlinstdlib" ["label"="kotlin-stdlib","shape"="rectangle"]
         "orgjetbrainsannotations" ["label"="jetbrains-annotations","shape"="rectangle"]
@@ -617,6 +634,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "android" ["label"="android","shape"="rectangle"]
         {
         edge ["dir"="none"]
@@ -638,6 +656,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "android" ["label"="android","shape"="rectangle"]
         {
         edge ["dir"="none"]
@@ -655,6 +674,7 @@ class DependencyGraphGeneratorTest {
       """
         digraph "G" {
         edge ["dir"="forward"]
+        graph ["dpi"="100"]
         "rxjava" ["label"="rxjava","shape"="rectangle"]
         "ioreactivexrxjava2rxjava" ["label"="rxjava","shape"="rectangle"]
         "orgreactivestreamsreactivestreams" ["label"="reactive-streams","shape"="rectangle"]


### PR DESCRIPTION
The https://github.com/nidi3/graphviz-java dependency overrides the default Graphviz dpi value to 72.
See #158 and https://github.com/nidi3/graphviz-java/issues/233 for more details.

Closes #158