### PR TITLE
Project Graph: Add dependencies from the root (declaration) nodes only

### DIFF
--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGenerator.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGenerator.kt
@@ -79,12 +79,13 @@ internal class ProjectDependencyGraphGenerator(
   }
 
   private fun addDependencies(dependencies: MutableList<ProjectDependencyContainer>, graph: MutableGraph) {
+    val rootNodes = graph.rootNodes().filter { it.links().isEmpty() }
     dependencies
       .filterNot { (from, to, _) -> from == to }
       .distinctBy { (from, to, _) -> from to to }
       .forEach { (from, to, isImplementation) ->
-        val fromNode = graph.nodes().find { it.name().toString() == from.path }
-        val toNode = graph.nodes().find { it.name().toString() == to.path }
+        val fromNode = rootNodes.single { it.name().toString() == from.path }
+        val toNode = rootNodes.single { it.name().toString() == to.path }
 
         if (fromNode != null && toNode != null) {
           val link = Link.to(toNode)


### PR DESCRIPTION
Closes nidi3/graphviz-java#234
Closes vanniktech/gradle-dependency-graph-generator-plugin#167

Not sure if this is an issue on the nidi3/graphviz-java repository. But there is no direct function to access declared nodes, meaning nodes without links (not edges).