### PR TITLE
Remove `rootProject` from Kotlin snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ import com.vanniktech.dependency.graph.generator.DependencyGraphGeneratorPlugin
 import guru.nidi.graphviz.attribute.Color
 import guru.nidi.graphviz.attribute.Style
 
-rootProject.plugins.apply(DependencyGraphGeneratorPlugin::class.java)
+plugins.apply(DependencyGraphGeneratorPlugin::class.java)
 
-rootProject.configure<DependencyGraphGeneratorExtension> {
+configure<DependencyGraphGeneratorExtension> {
   generators.create("jetbrainsLibraries") {
     include = { dependency -> dependency.moduleGroup.startsWith("org.jetbrains") } // Only want Jetbrains.
     children = { true } // Include transitive dependencies.


### PR DESCRIPTION
Applying the plugin on the root project my not be desirable.
And most projects will already apply this on the root project, so it's less confusing (and matches the groovy snippet)