### PR TITLE
Print distinct files

### DIFF
--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -34,6 +34,6 @@ import java.io.File
       graphviz.render(it).toFile(File(outputDirectory, generator.outputFileName))
     }
 
-    listOf(dot).plus(renders).forEach { logger.lifecycle(it.absolutePath) }
+    listOf(dot).plus(renders).distinct().forEach { logger.lifecycle(it.absolutePath) }
   }
 }

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
@@ -34,6 +34,6 @@ import java.io.File
       graphviz.render(it).toFile(File(outputDirectory, projectGenerator.outputFileName))
     }
 
-    listOf(dot).plus(renders).forEach { logger.lifecycle(it.absolutePath) }
+    listOf(dot).plus(renders).distinct().forEach { logger.lifecycle(it.absolutePath) }
   }
 }


### PR DESCRIPTION
If we specified

````kotlin
 outputFormats = listOf(DOT)
````

The .dot file would be printed twice.