### PR TITLE
Expose Graphviz instance

### DIFF
--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorExtension.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorExtension.kt
@@ -5,6 +5,7 @@ import guru.nidi.graphviz.attribute.Label
 import guru.nidi.graphviz.engine.Format
 import guru.nidi.graphviz.engine.Format.PNG
 import guru.nidi.graphviz.engine.Format.SVG
+import guru.nidi.graphviz.engine.Graphviz
 import guru.nidi.graphviz.model.MutableGraph
 import guru.nidi.graphviz.model.MutableNode
 import org.gradle.api.NamedDomainObjectContainer
@@ -77,6 +78,8 @@ open class DependencyGraphGeneratorExtension(project: Project) {
     @get:Nested var outputFormats: List<Format> = listOf(PNG, SVG),
     /** Allows you to mutate the [MutableGraph] and add things as needed. */
     @get:Nested var graph: (MutableGraph) -> MutableGraph = { it },
+    /** Allows you to configure the [Graphviz] instance. */
+    @get:Nested var graphviz: (Graphviz) -> Graphviz = { it },
   ) {
     /** Gradle task name that is associated with this generator. */
     @get:Internal val gradleTaskName = "generateDependencyGraph${
@@ -125,6 +128,8 @@ open class DependencyGraphGeneratorExtension(project: Project) {
     @get:Nested var outputFormats: List<Format> = listOf(PNG, SVG),
     /** Allows you to mutate the [MutableGraph] and add things as needed. */
     @get:Nested var graph: (MutableGraph) -> MutableGraph = { it },
+    /** Allows you to configure the [Graphviz] instance. */
+    @get:Nested var graphviz: (Graphviz) -> Graphviz = { it },
   ) {
     /** Gradle task name that is associated with this generator. */
     @get:Internal val gradleTaskName = "generateProjectDependencyGraph${

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -28,7 +28,7 @@ import java.io.File
     val dot = File(outputDirectory, generator.outputFileNameDot)
     dot.writeText(graph.toString())
 
-    val graphviz = Graphviz.fromGraph(graph).apply(generator.graphviz)
+    val graphviz = Graphviz.fromGraph(graph).run(generator.graphviz)
 
     val renders = generator.outputFormats.map {
       graphviz.render(it).toFile(File(outputDirectory, generator.outputFileName))

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -28,7 +28,7 @@ import java.io.File
     val dot = File(outputDirectory, generator.outputFileNameDot)
     dot.writeText(graph.toString())
 
-    val graphviz = Graphviz.fromGraph(graph)
+    val graphviz = Graphviz.fromGraph(graph).apply(generator.graphviz)
 
     val renders = generator.outputFormats.map {
       graphviz.render(it).toFile(File(outputDirectory, generator.outputFileName))

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
@@ -28,7 +28,7 @@ import java.io.File
     val dot = File(outputDirectory, projectGenerator.outputFileNameDot)
     dot.writeText(graph.toString())
 
-    val graphviz = Graphviz.fromGraph(graph)
+    val graphviz = Graphviz.fromGraph(graph).apply(projectGenerator.graphviz)
 
     val renders = projectGenerator.outputFormats.map {
       graphviz.render(it).toFile(File(outputDirectory, projectGenerator.outputFileName))

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorTask.kt
@@ -28,7 +28,7 @@ import java.io.File
     val dot = File(outputDirectory, projectGenerator.outputFileNameDot)
     dot.writeText(graph.toString())
 
-    val graphviz = Graphviz.fromGraph(graph).apply(projectGenerator.graphviz)
+    val graphviz = Graphviz.fromGraph(graph).run(projectGenerator.graphviz)
 
     val renders = projectGenerator.outputFormats.map {
       graphviz.render(it).toFile(File(outputDirectory, projectGenerator.outputFileName))


### PR DESCRIPTION
On big projects, we need to update Graphviz's `totalMemory`, otherwise we get an error.

This would allow us to configure Graphviz's internals:

```kotlin
graphviz = { it.totalMemory( /*...*/ ) }
```