### PR TITLE
Fix destination project might not be included

### DIFF
--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGenerator.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGenerator.kt
@@ -12,6 +12,7 @@ import guru.nidi.graphviz.model.Factory.mutGraph
 import guru.nidi.graphviz.model.Factory.mutNode
 import guru.nidi.graphviz.model.Link
 import guru.nidi.graphviz.model.MutableGraph
+import guru.nidi.graphviz.model.MutableNode
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 
@@ -71,18 +72,15 @@ internal class ProjectDependencyGraphGenerator(
   }
 
   private fun addDependencies(dependencies: MutableList<ProjectDependencyContainer>, graph: MutableGraph) {
-    val rootNodes = graph.rootNodes().filter { it.links().isEmpty() }
+    val rootNodes: List<MutableNode> = graph.rootNodes().filter { it.links().isEmpty() }
     dependencies
       .filterNot { (from, to, _) -> from == to }
       .distinctBy { (from, to, _) -> from to to }
       .forEach { (from, to, isImplementation) ->
         val fromNode = rootNodes.single { it.name().toString() == from.path }
-        val toNode = rootNodes.single { it.name().toString() == to.path }
-
-        if (fromNode != null && toNode != null) {
-          val link = Link.to(toNode)
-          graph.add(fromNode.addLink(if (isImplementation) link.with(Style.DOTTED) else link))
-        }
+        val toNode = rootNodes.singleOrNull { it.name().toString() == to.path } ?: return@forEach
+        val link = Link.to(toNode)
+        graph.add(fromNode.addLink(if (isImplementation) link.with(Style.DOTTED) else link))
       }
   }
 

--- a/src/test/java/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorIncludeProjectTest.kt
+++ b/src/test/java/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorIncludeProjectTest.kt
@@ -35,7 +35,7 @@ class ProjectDependencyGraphGeneratorIncludeProjectTest {
 
   @Test fun excludeNonLeafProject() {
     assertEquals(
-      // language=DOT
+      // language=dot
       """
       digraph {
       edge ["dir"="forward"]

--- a/src/test/java/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorIncludeProjectTest.kt
+++ b/src/test/java/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorIncludeProjectTest.kt
@@ -57,7 +57,7 @@ class ProjectDependencyGraphGeneratorIncludeProjectTest {
 
   @Test fun excludeLeafProject() {
     assertEquals(
-      // language=DOT
+      // language=dot
       """
       digraph {
       edge ["dir"="forward"]

--- a/src/test/java/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorIncludeProjectTest.kt
+++ b/src/test/java/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGeneratorIncludeProjectTest.kt
@@ -1,0 +1,79 @@
+package com.vanniktech.dependency.graph.generator
+
+import com.vanniktech.dependency.graph.generator.DependencyGraphGeneratorExtension.ProjectGenerator.Companion.ALL
+import org.gradle.api.Project
+import org.gradle.api.plugins.JavaLibraryPlugin
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class ProjectDependencyGraphGeneratorIncludeProjectTest {
+
+  private lateinit var root: Project
+  private lateinit var app: Project
+  private lateinit var lib1: Project
+  private lateinit var lib2: Project
+
+  @Before fun setUp() {
+    root = ProjectBuilder.builder().withName("root").build()
+    root.plugins.apply(JavaLibraryPlugin::class.java)
+
+    app = ProjectBuilder.builder().withParent(root).withName("app").build()
+    app.plugins.apply(JavaLibraryPlugin::class.java)
+
+    lib1 = ProjectBuilder.builder().withParent(root).withName("lib1").build()
+    lib1.plugins.apply(JavaLibraryPlugin::class.java)
+
+    lib2 = ProjectBuilder.builder().withParent(root).withName("lib2").build()
+    lib2.plugins.apply(JavaLibraryPlugin::class.java)
+
+    app.dependencies.add("implementation", lib1)
+    app.dependencies.add("implementation", lib2)
+    lib1.dependencies.add("implementation", lib2)
+  }
+
+  @Test fun excludeNonLeafProject() {
+    assertEquals(
+      // language=DOT
+      """
+      digraph {
+      edge ["dir"="forward"]
+      graph ["dpi"="100","label"="root","labelloc"="t","fontsize"="35"]
+      node ["style"="filled"]
+      ":app" ["shape"="rectangle","fillcolor"="#FF7043"]
+      ":lib2" ["fillcolor"="#FF7043"]
+      {
+      edge ["dir"="none"]
+      graph ["rank"="same"]
+      ":app"
+      }
+      ":app" -> ":lib2" ["style"="dotted"]
+      }
+      """.trimIndent(),
+      ProjectDependencyGraphGenerator(root, ALL.copy(includeProject = { it != lib1 })).generateGraph().toString()
+    )
+  }
+
+  @Test fun excludeLeafProject() {
+    assertEquals(
+      // language=DOT
+      """
+      digraph {
+      edge ["dir"="forward"]
+      graph ["dpi"="100","label"="root","labelloc"="t","fontsize"="35"]
+      node ["style"="filled"]
+      ":app" ["shape"="rectangle","fillcolor"="#FF7043"]
+      ":lib1" ["fillcolor"="#FF7043"]
+      {
+      edge ["dir"="none"]
+      graph ["rank"="same"]
+      ":app"
+      }
+      ":app" -> ":lib1" ["style"="dotted"]
+      }
+      """.trimIndent(),
+      ProjectDependencyGraphGenerator(root, ALL.copy(includeProject = { it != lib2 })).generateGraph().toString()
+    )
+  }
+}


### PR DESCRIPTION
When filtering out projects with `ProjectGenerator.includeProject`, the process will throw a `NoSuchElementException("Collection contains no element matching the predicate.")` because the destination project has been filtered out of the root nodes.

I'm making it as a draft because I'd like to create a test for it (there might be the same issue as well for the `DependencyGraphGenerator`).
The regression was introduced in https://github.com/vanniktech/gradle-dependency-graph-generator-plugin/commit/8f7c8296b704d84dde35a0d92b22f4b5d66a5a9b.