### PR TITLE
#174 Update DependencyGraphGeneratorTask.kt

### DIFF
--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/DependencyGraphGeneratorTask.kt
@@ -28,7 +28,7 @@ import java.io.File
     val dot = File(outputDirectory, generator.outputFileNameDot)
     dot.writeText(graph.toString())
 
-    val graphviz = Graphviz.fromGraph(graph).run(generator.graphviz)
+    val graphviz = Graphviz.fromGraph(graph).totalMemory(999999999).run(generator.graphviz)
 
     val renders = generator.outputFormats.map {
       graphviz.render(it).toFile(File(outputDirectory, generator.outputFileName))


### PR DESCRIPTION
Fixes #174 

Set a high upper bound for total memory to prevent failure:

> Cannot enlarge memory arrays. Either (1) compile with  -s TOTAL_MEMORY=X  with X higher than the current value 16777216, (2) compile with  -s ALLOW_MEMORY_GROWTH=1  which allows increasing the size at runtime but prevents some optimizations, (3) set Module.TOTAL_MEMORY to a higher value before the program runs, or (4) if you want malloc to return NULL (0) instead of this abort, compile with  -s ABORTING_MALLOC=0