### PR TITLE
Update Kotlin Multiplatform ProjectTarget color to improve color contrast accessibility

### DIFF
--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectTarget.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectTarget.kt
@@ -24,7 +24,7 @@ internal enum class ProjectTarget(
   ),
   MULTIPLATFORM(
     ids = setOf("org.jetbrains.kotlin.multiplatform"),
-    color = Color.rgb("#AB47BC").fill(),
+    color = Color.rgb("#A280FF").fill(),
   ),
   OTHER(
     ids = emptySet(),


### PR DESCRIPTION
### Description

Update Kotlin Multiplatform `ProjectTarget` color to improve color contrast accessibility. New color is based on Kotlin brand assets resources `#7F52FF` with lightness applied `#A280FF`.

-----

### Before

<img width="520" alt="Screenshot 2023-02-12 at 19 17 07" src="https://user-images.githubusercontent.com/26246782/218330213-75b489aa-c052-429a-8b3f-5994b4322557.png">
<img width="720" alt="project-dependency-graph 2" src="https://user-images.githubusercontent.com/26246782/218330217-c3bbdd84-99f0-4e43-b382-0d20ba6d8548.svg">

-----

### After

<img width="520" alt="Screenshot 2023-02-12 at 19 17 07" src="https://user-images.githubusercontent.com/26246782/218330226-c0b451e7-2278-42c7-a0ae-7f04dc6997ca.png">
<img width="720" alt="project-dependency-graph 2" src="https://user-images.githubusercontent.com/26246782/218330258-d60a5884-bc47-481f-a678-d0dfccb22628.svg">