### PR TITLE
Fix duplicated tree links in Gradle 8.10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ out/
 
 .idea/
 *.iml
+
+local.properties

--- a/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGenerator.kt
+++ b/src/main/kotlin/com/vanniktech/dependency/graph/generator/ProjectDependencyGraphGenerator.kt
@@ -76,6 +76,7 @@ internal class ProjectDependencyGraphGenerator(
     val rootNodes: List<MutableNode> = graph.rootNodes().filterNotNull().filter { it.links().isEmpty() }
     dependencies
       .filterNot { (from, to, _) -> from == to }
+      .distinctBy { it.from.path to it.to.path }
       .forEach { (from, to, configuration) ->
         val fromNode = rootNodes.single { it.name().toString() == from.path }
         val toNode = rootNodes.singleOrNull { it.name().toString() == to.path } ?: return@forEach


### PR DESCRIPTION
Honestly I'm not sure exactly what causes my issue, but when I bumped my project up from Gradle 8.9 to 8.10 I started getting duplicated links in my project dependency tree. So it would generate a dotfile something like:
```dot
digraph {
...

":a"
":b"
":c"
":d"

":a" -> ":b"
":a" -> ":b"
":a" -> ":b"
":a" -> ":c"
":a" -> ":c"
":b" -> ":d"
}
```

when before it would only have one instance of each module link. The duplication would happen at seemingly random frequencies, but it was repeatable for the same module links.

This PR squashes the issue by forcing uniqueness of the pair of "from" and "to" nodes on the `ProjectDependencyContainer` class. All tests pass okay and the dotfile comes out okay on my machine, but I'd be interested to see whether anyone else sees something similar.

Also added local.properties to gitignore, hopefully this isn't an issue